### PR TITLE
Fix resource:* commands to use correct hostname for SSH

### DIFF
--- a/src/Flownative/Beach/Cli/Command/Resources/DownloadCommand.php
+++ b/src/Flownative/Beach/Cli/Command/Resources/DownloadCommand.php
@@ -87,10 +87,10 @@ Note: Existing data in the local project instance will be left unchanged.
         $io->newLine();
 
         $environmentVariables = [];
-        exec('ssh -J beach@ssh.flownative.cloud beach@' . $instanceIdentifier . ' /bin/bash -c "env | grep BEACH_GOOGLE_CLOUD_STORAGE_"', $environmentLines);
+        exec('ssh -J beach@ssh.flownative.cloud beach@' . $instanceIdentifier . '.beach /bin/bash -c "env | grep BEACH_GOOGLE_CLOUD_STORAGE_"', $environmentLines);
 
         foreach ($environmentLines as $line) {
-            list($key, $value) = explode("=", $line);
+            [$key, $value] = explode('=', $line);
             $environmentVariables[$key] = $value;
         }
 

--- a/src/Flownative/Beach/Cli/Command/Resources/UploadCommand.php
+++ b/src/Flownative/Beach/Cli/Command/Resources/UploadCommand.php
@@ -88,7 +88,7 @@ Note: Existing data in the Beach instance will be left unchanged.
         $io->newLine();
 
         $environmentVariables = [];
-        exec('ssh -J beach@ssh.flownative.cloud beach@' . $instanceIdentifier . ' /bin/bash -c "env | grep BEACH_GOOGLE_CLOUD_STORAGE_"', $environmentLines);
+        exec('ssh -J beach@ssh.flownative.cloud beach@' . $instanceIdentifier . '.beach /bin/bash -c "env | grep BEACH_GOOGLE_CLOUD_STORAGE_"', $environmentLines);
 
         foreach ($environmentLines as $line) {
             list($key, $value) = explode("=", $line);


### PR DESCRIPTION
The new requirement to have instance hostnames end with .beach is now
implemented.